### PR TITLE
feat: filter SHA tag webhook notifications from Harbor 2.8+

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v6
         with:
-          go-version: stable
+          go-version-file: 'go.mod'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -26,8 +26,8 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v6
         with:
-          go-version-file: 'go.mod'
+          go-version: stable
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.1
+          version: latest

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.dll
 *.so
 *.dylib
+htb
 
 # Other
 *.log

--- a/dockerfile
+++ b/dockerfile
@@ -1,5 +1,5 @@
 # Stage 1
-FROM golang:1.24 as build
+FROM golang:1.26 as build
 WORKDIR /app
 
 COPY go.mod ./

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,5 @@
 module htb
-go 1.24
-require (
-	github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1 // indirect
-	github.com/technoweenie/multipartstreamer v1.0.1 // indirect
-)
+
+go 1.26
+
+require github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,2 @@
-github.com/go-telegram-bot-api/telegram-bot-api v4.6.4+incompatible h1:2cauKuaELYAEARXRkq2LrJ0yDDv1rW7+wrTEdVL3uaU=
-github.com/go-telegram-bot-api/telegram-bot-api v4.6.4+incompatible/go.mod h1:qf9acutJ8cwBUhm1bqgz6Bei9/C/c93FPDljKWwsOgM=
 github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1 h1:wG8n/XJQ07TmjbITcGiUaOtXxdrINDz1b0J1w0SzqDc=
 github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1/go.mod h1:A2S0CWkNylc2phvKXWBBdD3K0iGnDBGbzRpISP2zBl8=
-github.com/technoweenie/multipartstreamer v1.0.1 h1:XRztA5MXiR1TIRHxH2uNxXxaIkKQDeX7m2XsSOlQEnM=
-github.com/technoweenie/multipartstreamer v1.0.1/go.mod h1:jNVxdtShOxzAsukZwTSw6MDx5eUJoiEBsSvzDU9uzog=

--- a/main.go
+++ b/main.go
@@ -103,6 +103,12 @@ func init() {
 	warnEnv := os.Getenv("WARN_ON_PUSH")
 	Warn = strings.ToLower(warnEnv) == "true"
 }
+var FilterSHATags bool
+func init() {
+	filterEnv := os.Getenv("FILTER_SHA_TAGS")
+	// Default true — filter SHA tags unless explicitly set to "false"
+	FilterSHATags = strings.ToLower(filterEnv) != "false"
+}
 // ================= INIT BOT =================
 func initTelegramBot() {
 	var err error
@@ -191,6 +197,10 @@ func calcQuotaUsage(used, hard int64) QuotaInfo {
     }
 
     return QuotaInfo{TotalMB: totalMB, UsedMB:  usedMB, Percent: percent, Warning: warning, }
+}
+
+func isSHATag(tag string) bool {
+	return strings.HasPrefix(tag, "sha256:")
 }
 
 func getArtifact(resource Resource, repo Repository) (HarborArtifact, error) {
@@ -362,6 +372,18 @@ func handleWebhook(w http.ResponseWriter, r *http.Request) {
 	if err := json.Unmarshal(body, &payload); err != nil {
 		http.Error(w, "ERROR!!! Invalid JSON", http.StatusBadRequest)
 		return
+	}
+
+	// Filter SHA digest tags (Harbor 2.8+ fires interim webhook before renaming artifact)
+	if FilterSHATags && len(payload.EventData.Resources) > 0 {
+		tag := payload.EventData.Resources[0].Tag
+		if isSHATag(tag) {
+			log.Printf("INFO: SHA tag filtered — repo: %s, tag: %s",
+				payload.EventData.Repository.RepoFullName, tag)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("OK! SHA tag filtered."))
+			return
+		}
 	}
 
 	chatIdStr := os.Getenv("CHAT_ID")


### PR DESCRIPTION
Harbor 2.8+ sends an interim webhook for OCI Helm artifacts with a
sha256: digest as the tag before renaming to the real tag, causing
duplicate spam notifications. Add isSHATag() predicate and early-return
guard in handleWebhook() to drop these before any Harbor API calls or
Telegram sends. Controlled via FILTER_SHA_TAGS env var (default: true).